### PR TITLE
Add script to manage automatic deploys to staging/production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: deploy
+on:
+  push:
+    branches:
+      - dev
+      - master
+      - automatic-deploys
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install packages
+        run: yarn --prefer-offline
+
+      - name: Build CLI and rule definitions
+        run: yarn build
+
+  deploy-staging:
+    name: Deploy to Staging
+    if: github.event.ref == 'refs/heads/automatic-deploys'
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: Staging
+    steps:
+      - name: Deploy
+        env:
+          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+          TOKEN_NAMESPACE: ${{ secrets.TOKEN_NAMESPACE }}
+        run: yarn rules deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - dev
       - master
-      - automatic-deploys
 jobs:
   build:
     name: Deploy
@@ -20,9 +19,7 @@ jobs:
 
       # See https://www.maxivanov.io/github-actions-deploy-to-multiple-environments-from-single-workflow/
       - name: Set environment vars (staging)
-        if:
-          endsWith(github.ref, '/dev') || endsWith(github.ref,
-          '/automatic-deploys')
+        if: endsWith(github.ref, '/dev')
         run: |
           echo "AUTH0_DOMAIN=${{ secrets.STAGING__AUTH0_DOMAIN}}" >> $GITHUB_ENV
           echo "AUTH0_CLIENT_ID=${{ secrets.STAGING__AUTH0_CLIENT_ID}}" >> $GITHUB_ENV

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
       - automatic-deploys
 jobs:
   build:
-    name: Build
+    name: Deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +20,9 @@ jobs:
 
       # See https://www.maxivanov.io/github-actions-deploy-to-multiple-environments-from-single-workflow/
       - name: Set environment vars (staging)
-        if: endsWith(github.ref, '/dev')
+        if:
+          endsWith(github.ref, '/dev') || endsWith(github.ref,
+          '/automatic-deploys')
         run: |
           echo "AUTH0_DOMAIN=${{ secrets.STAGING__AUTH0_DOMAIN}} >> $GITHUB_ENV
           echo "AUTH0_CLIENT_ID=${{ secrets.STAGING__AUTH0_CLIENT_ID}} >> $GITHUB_ENV

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,16 +24,16 @@ jobs:
           endsWith(github.ref, '/dev') || endsWith(github.ref,
           '/automatic-deploys')
         run: |
-          echo "AUTH0_DOMAIN=${{ secrets.STAGING__AUTH0_DOMAIN}} >> $GITHUB_ENV
-          echo "AUTH0_CLIENT_ID=${{ secrets.STAGING__AUTH0_CLIENT_ID}} >> $GITHUB_ENV
-          echo "AUTH0_CLIENT_SECRET=${{ secrets.STAGING__AUTH0_CLIENT_SECRET}} >> $GITHUB_ENV
+          echo "AUTH0_DOMAIN=${{ secrets.STAGING__AUTH0_DOMAIN}}" >> $GITHUB_ENV
+          echo "AUTH0_CLIENT_ID=${{ secrets.STAGING__AUTH0_CLIENT_ID}}" >> $GITHUB_ENV
+          echo "AUTH0_CLIENT_SECRET=${{ secrets.STAGING__AUTH0_CLIENT_SECRET}}" >> $GITHUB_ENV
 
       - name: Set environment vars (production)
         if: endsWith(github.ref, '/master')
         run: |
-          echo "AUTH0_DOMAIN=${{ secrets.PRODUCTION__AUTH0_DOMAIN}} >> $GITHUB_ENV
-          echo "AUTH0_CLIENT_ID=${{ secrets.PRODUCTION__AUTH0_CLIENT_ID}} >> $GITHUB_ENV
-          echo "AUTH0_CLIENT_SECRET=${{ secrets.PRODUCTION__AUTH0_CLIENT_SECRET}} >> $GITHUB_ENV
+          echo "AUTH0_DOMAIN=${{ secrets.PRODUCTION__AUTH0_DOMAIN}}" >> $GITHUB_ENV
+          echo "AUTH0_CLIENT_ID=${{ secrets.PRODUCTION__AUTH0_CLIENT_ID}}" >> $GITHUB_ENV
+          echo "AUTH0_CLIENT_SECRET=${{ secrets.PRODUCTION__AUTH0_CLIENT_SECRET}}" >> $GITHUB_ENV
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,21 @@ jobs:
         with:
           node-version: 14
 
+      # See https://www.maxivanov.io/github-actions-deploy-to-multiple-environments-from-single-workflow/
+      - name: Set environment vars (staging)
+        if: endsWith(github.ref, '/dev')
+        run: |
+          echo "AUTH0_DOMAIN=${{ secrets.STAGING__AUTH0_DOMAIN}} >> $GITHUB_ENV
+          echo "AUTH0_CLIENT_ID=${{ secrets.STAGING__AUTH0_CLIENT_ID}} >> $GITHUB_ENV
+          echo "AUTH0_CLIENT_SECRET=${{ secrets.STAGING__AUTH0_CLIENT_SECRET}} >> $GITHUB_ENV
+
+      - name: Set environment vars (production)
+        if: endsWith(github.ref, '/master')
+        run: |
+          echo "AUTH0_DOMAIN=${{ secrets.PRODUCTION__AUTH0_DOMAIN}} >> $GITHUB_ENV
+          echo "AUTH0_CLIENT_ID=${{ secrets.PRODUCTION__AUTH0_CLIENT_ID}} >> $GITHUB_ENV
+          echo "AUTH0_CLIENT_SECRET=${{ secrets.PRODUCTION__AUTH0_CLIENT_SECRET}} >> $GITHUB_ENV
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -37,19 +52,7 @@ jobs:
       - name: Build CLI and rule definitions
         run: yarn build
 
-  deploy-staging:
-    name: Deploy to Staging
-    if: github.event.ref == 'refs/heads/automatic-deploys'
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: Staging
-    steps:
       - name: Deploy
         env:
-          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
           TOKEN_NAMESPACE: ${{ secrets.TOKEN_NAMESPACE }}
         run: yarn rules deploy


### PR DESCRIPTION
Adds an automatic deploy script to deploy new rules pushed to `dev` or `master` (to our staging and production Auth0 tenants, respectively).

The script is pretty standard, but I've used [the logic described here](https://www.maxivanov.io/github-actions-deploy-to-multiple-environments-from-single-workflow/) to switch which environment variables are loaded in staging and production.

You can see an example of a successful run [here](https://github.com/centre-for-effective-altruism/auth0-rules/actions/runs/758516006). (This ran against this branch, i.e. `automatic-deploys`, but I've since removed this from the deploy script. You can see that the rules are live on the staging Auth0 tenant.

The rules as currently defined should be compatible with our existing applications, but we'll need to redeploy the rules once we've deployed the RBAC changes in Parfit/Lyra/Aletheia (as the roles we auto-add to users when they log in aren't currently referenced in the rule that adds them, because they don't exist on the tenant yet).