### PR TITLE
Bypass recent temporary_person in getUser

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Deploy
         env:
           TOKEN_NAMESPACE: ${{ secrets.TOKEN_NAMESPACE }}
-        run: yarn rules deploy
+        run: yarn cli rules deploy && yarn cli db deploy


### PR DESCRIPTION
This updates the `getUser` database script to return an empty profile if a person was recently created as part of the new `temporary_person` flow.

`getUser` is used by Auth0 to determine whether a user exists, in order to prevent duplicate registrations. In the new temporary person flow, we create a `person` record under the hood, linked by email address. However, this presents us with a problem if that person wants to create an account (e.g. after they've completed their payment). When the user goes to sign up, the `getUser` script will fire, and will report that the person already exists, blocking the signup. While this is normally what you want (because we don't want people with existing accounts to be able to sign up with an existing email address), in this case, we know that the person has just created their account, and crucially, that they won't have a password set.

This modification adds an additional check to see if a person has been recently created by a still-valid `temporary_person` session. If so, instead of returning the person's profile, it lies to Auth0, and returns an empty profile. Auth0 interprets this as the person not existing, and lets the signup proceed.

## Some issues with this approach

I've chosen to go for this approach as it seems like the best way to allow users to create an account after making a payment without signing in. It doesn't require us to do anything hacky (like reinventing a separate interface for creating accounts, where we set passwords for users in the background), the signup flow is basically identical to our existing practice, and the user is signed in immediately after creating an account (if we created the account for them via the API through e.g. the EA Funds UI, they'd still have to go through Auth0 afterwards to sign in).

However, there are a few drawbacks to this approach:

- A user who has created their account through the temporary person flow will not be able to request a password reset while their session token is still valid. I think this is probably fine – the session tokens are pretty short lived, and it's unlikely the person will be trying to reset their password if they have no account.
- There's a small window for an attacker to hijack a user's account, if a) a user completes the temporary person flow and creates a `person` record as part of it, b) the user does not create an account themselves, and c) the attacker signs up for an account under that user's email address before the session token expires. I think that the risk here is extremely low, but it's worth discussing. Unfortunately as far as I can tell there's no way to pass state into the `getUser` function (if there was, we could pass in the session token, and use that to validate the user).