### PR TITLE
Don't show login help on signup

### DIFF
--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -145,9 +145,21 @@
       }
     </script>
   </head>
+  {% comment %}
+    Pretty freaking hacky - there's surely a better way to save conditional
+    variables in liquid, but I don't know it
+  {% endcomment %}
+  {% capture is_forum_login %}
+    {% if application.name contains "Forum" and prompt.name == "login" %}
+      true
+    {% else %}
+      false
+    {% endif %}
+  {% endcapture %}
   <body>
-    <div class="ea-layout {% if application.name contains "Forum" %}ea-layout-forum{% else %}ea-layout-contact{% endif %}">
-      {% if application.name contains "Forum" %}
+    <p>"{{ is_forum_login }}"</p>
+    <div class="ea-layout {% if is_forum_login contains "true" %}ea-layout-forum{% else %}ea-layout-contact{% endif %}">
+      {% if is_forum_login contains "true" %}
         <div class="forum-instructions">
           <p>Welcome to our new login page!</p>
           <div class="open" id="forum-instructions-details">
@@ -177,7 +189,7 @@
       <div class="widget-wrapper">
         {%- auth0:widget -%}
       </div>
-      {% if application.name contains "Forum" %}
+      {% if is_forum_login contains "true" %}
         <div class="forum-instructions-balancer"></div>
       {% else %}
         <div class="contact-us">

--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -157,7 +157,6 @@
     {% endif %}
   {% endcapture %}
   <body>
-    <p>"{{ is_forum_login }}"</p>
     <div class="ea-layout {% if is_forum_login contains "true" %}ea-layout-forum{% else %}ea-layout-contact{% endif %}">
       {% if is_forum_login contains "true" %}
         <div class="forum-instructions">


### PR DESCRIPTION
Login help is login-specific, so we should only show it when the auth0 prompt is login.

Is contains a pretty hacky way to save a variable. I got exasperated after like twenty minutes of looking for a better way.