### PR TITLE
GWWC Branded login

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ rules.
 
 ## Usage
 
-Sync with Auth0 using `yarn cli [rules|db]`
+Sync with Auth0 using `yarn cli [rules|db|login]`
 
 ```
 Usage: yarn cli rules [options] [command]
@@ -109,7 +109,7 @@ Commands:
 #### `deploy`
 
 ```sh
-yarn [rules|db] deploy
+yarn [rules|db|login] deploy
 ```
 
 Deploys all scripts in the manifest to Auth0.
@@ -122,7 +122,7 @@ are in the manifest.
 #### `diff`
 
 ```
-yarn [rules|db] diff
+yarn [rules|db|login] diff
 ```
 
 Diffs locally defined scripts against those defined on the Auth0 tenant.
@@ -229,8 +229,8 @@ Defining the script itself (as a file in e.g. `./scripts/rules/src`)
 
 - [Registering the script in the manifest](#the-manifest) (`./src/manifests`)
 
-Scripts are defined in `./scripts/[rules|db]/src`. Each script lives in its own
-file. They are written as Typescript files (`.ts` extension).
+Scripts are defined in `./scripts/[rules|db|login]/src`. Each script lives in
+its own file. They are written as Typescript files (`.ts` extension).
 
 ### Basic rule structure
 

--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -33,7 +33,7 @@
         width: 120px;
         height: 120px;
         margin: var(--logo-alignment);
-        background-image: url(https://upload.wikimedia.org/wikipedia/en/3/38/Giving_What_We_Can_text_logo.jpg);
+        background-image: url(https://res.cloudinary.com/cea/image/upload/v1629107364/GWWC_square_logo.png);
         background-size: contain;
       }
     </style>

--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -15,7 +15,8 @@
       body {
         background: var(--page-background-color) !important;
       }
-      button[value="default"] {
+      /* Sign up button and accept access buttons */
+      button[value="default"], button[value="accept"] {
         background-color: var(--primary-color) !important;
       }
       /* GWWC LOGO: hide img + abuse h1 to show GWWC logo */

--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -3,6 +3,40 @@
   <head>
     {%- auth0:head -%}
     <link rel="shortcut icon" href="https://www.effectivealtruism.org/favicon-16x16.png">
+    {% if application.name contains "Giving" %}
+    <style>
+      /* GWWC COLORS */
+      :root {
+        --page-background-color: white;
+        --primary-color:  #6c0000;
+        --action-primary-color: #6c0000;
+      }
+      /* setting above variables should be enough, but somehow auth0 also decides to add a second css line with the colors hardcoded, so we need to mark these vars as important */
+      body {
+        background: var(--page-background-color) !important;
+      }
+      button[value="default"] {
+        background-color: var(--primary-color) !important;
+      }
+      /* GWWC LOGO: hide img + abuse h1 to show GWWC logo */
+      #prompt-logo-center {
+        display: none;
+      }
+      h1 {
+        text-indent: -9999999px;
+        font-size: 0px !important;
+      }
+      h1:after {
+        content: "";
+        display: block;
+        width: 120px;
+        height: 120px;
+        margin: var(--logo-alignment);
+        background-image: url(https://upload.wikimedia.org/wikipedia/en/3/38/Giving_What_We_Can_text_logo.jpg);
+        background-size: contain;
+      }
+    </style>
+    {% endif %}
     <style>
       :root {
         --forum-instructions-width: 300px;


### PR DESCRIPTION
When logging into the Giving What We Can app, the login will now look like:

![image](https://user-images.githubusercontent.com/47074382/129439297-9032328e-aacd-44af-83d0-dcae87177345.png)

This required some CSS hackery as:

1. The logo cannot be updated through the settings, even if the Giving What We Can app has the GWWC logo in Auth0, the EA logo will still show up
2. The colours cannot be defined per app.. 
3. Somehow Auth0 hard-codes the colors in CSS instead of only using the css-variables.. so I needed to sprinkle in some `!important`s

Note that from an accessibility standpoint, these are not really desired changes (hiding elements, using pseudo-elements), but it shouldn't interfere too much with usage of the form.


I'm using the logo from Wikipedia.. please point me to where we normally would get these assets from :) 