### PR TITLE
Update GWWC Logo and colours on login page

### DIFF
--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -8,8 +8,8 @@
       /* GWWC COLORS */
       :root {
         --page-background-color: white;
-        --primary-color:  #6c0000;
-        --action-primary-color: #6c0000;
+        --primary-color:  #ab2b24;
+        --action-primary-color: #ab2b24;
       }
       /* setting above variables should be enough, but somehow auth0 also decides to add a second css line with the colors hardcoded, so we need to mark these vars as important */
       body {
@@ -33,7 +33,7 @@
         width: 120px;
         height: 120px;
         margin: var(--logo-alignment);
-        background-image: url(https://res.cloudinary.com/cea/image/upload/v1629107364/GWWC_square_logo.png);
+        background-image: url(https://images.ctfassets.net/dhpcfh1bs3p6/38hxh2plUIgaIIkE08CE2M/539859238d68f6b06373763c7633c836/GWWC-Color__1_.png?h=250);
         background-size: contain;
       }
     </style>


### PR DESCRIPTION
Before:
<img width="461" alt="Screenshot 2022-01-03 at 16 03 48" src="https://user-images.githubusercontent.com/15565/147946321-2295540d-2093-4673-90dc-76762c717d50.png">

After:
<img width="442" alt="Screenshot 2022-01-03 at 16 04 49" src="https://user-images.githubusercontent.com/15565/147946329-1a4847a2-44b9-4c81-bd42-79f5cd85b13d.png">

