### PR TITLE
Change error message during signup in cases where a `person` entry exists

### DIFF
--- a/cli/commands/login/deploy.ts
+++ b/cli/commands/login/deploy.ts
@@ -3,16 +3,37 @@ import path from 'path'
 import auth0 from '../../lib/client'
 
 export default async function run() {
-  const branding = auth0.branding
   try {
-    const newTemplate = (
-      await fs.readFile(path.join(__dirname, '../../../templates/login.liquid'))
-    ).toString()
-    await branding.setUniversalLoginTemplate(undefined, {
-      template: newTemplate,
-    })
+    await deployLoginTemplate()
+    await deployCustomText()
   } catch (err) {
     console.log('err', err)
     process.exit(1)
   }
+}
+
+async function deployLoginTemplate() {
+  const branding = auth0.branding
+  const newTemplate = (
+    await fs.readFile(path.join(__dirname, '../../../templates/login.liquid'))
+  ).toString()
+  await branding.setUniversalLoginTemplate(undefined, {
+    template: newTemplate,
+  })
+}
+
+async function deployCustomText() {
+  const customText = JSON.parse(
+    (
+      await fs.readFile(
+        path.join(__dirname, '../../../templates/custom-text.json')
+      )
+    ).toString()
+  )
+
+  auth0.prompts.updateCustomTextByLanguage({
+    prompt: 'signup',
+    language: 'en',
+    body: customText,
+  })
 }

--- a/cli/commands/login/diff.ts
+++ b/cli/commands/login/diff.ts
@@ -1,35 +1,65 @@
 import auth0 from '../../lib/client'
 import { fs } from 'mz'
 import path from 'path'
-import { printCodeDiff } from '../../lib/utils'
+import { printCodeDiff, deepSortObject } from '../../lib/utils'
 import { diffLines } from 'diff'
 
 export default async function run() {
   try {
-    const branding = auth0.branding
-    let existingTemplate
-    try {
-      existingTemplate = (await branding.getUniversalLoginTemplate()).body
-    } catch (err) {
-      if (err.statusCode === 404) {
-        existingTemplate = ''
-      } else {
-        throw err
-      }
-    }
-    const newTemplate = (
-      await fs.readFile(path.join(__dirname, '../../../templates/login.liquid'))
-    ).toString()
-    const diff = diffLines(existingTemplate, newTemplate)
-    const upToDateTemplates = printCodeDiff(
-      [[{ name: 'Login' }, diff]],
-      'login'
-    )
-    if (upToDateTemplates.length) {
-      console.log('Login template is up-to-date')
-    }
+    await diffLoginTemplate()
+    await diffCustomText()
   } catch (err) {
     console.log(err)
     process.exit(1)
+  }
+}
+
+async function diffLoginTemplate() {
+  const branding = auth0.branding
+  let existingTemplate
+  try {
+    existingTemplate = (await branding.getUniversalLoginTemplate()).body
+  } catch (err) {
+    if (err.statusCode === 404) {
+      existingTemplate = ''
+    } else {
+      throw err
+    }
+  }
+  const newTemplate = (
+    await fs.readFile(path.join(__dirname, '../../../templates/login.liquid'))
+  ).toString()
+  const diff = diffLines(existingTemplate, newTemplate)
+  const upToDateTemplates = printCodeDiff([[{ name: 'Login' }, diff]], 'login')
+  if (upToDateTemplates.length) {
+    console.log('✔ Login template is up-to-date')
+  }
+}
+
+async function diffCustomText() {
+  const existingCustomText = await auth0.prompts.getCustomTextByLanguage({
+    prompt: 'signup',
+    language: 'en',
+  })
+  const sortedExistingCustomText = deepSortObject(existingCustomText)
+
+  const newCustomText = JSON.parse(
+    (
+      await fs.readFile(
+        path.join(__dirname, '../../../templates/custom-text.json')
+      )
+    ).toString()
+  )
+  const sortedNewCustomText = deepSortObject(newCustomText)
+  const textDiff = diffLines(
+    JSON.stringify(sortedExistingCustomText),
+    JSON.stringify(sortedNewCustomText)
+  )
+  const upToDateCustomText = printCodeDiff(
+    [[{ name: 'CustomText' }, textDiff]],
+    'login'
+  )
+  if (upToDateCustomText.length) {
+    console.log('✔ Login custom text is up-to-date')
   }
 }

--- a/cli/lib/utils.ts
+++ b/cli/lib/utils.ts
@@ -213,3 +213,24 @@ export function printCodeDiff<
   }
   return upToDateScripts
 }
+
+type diffObject = { [key: string]: string | diffObject }
+
+/**
+ * Deep sorts an object of string values
+ *
+ * For example: deepSortObject({test: {x: 'value', a: 'other value'}})
+ */
+export function deepSortObject(obj: diffObject) {
+  return Object.keys(obj)
+    .sort()
+    .reduce(function (result, key) {
+      const x = obj[key]
+      if (typeof x === 'object') {
+        result[key] = deepSortObject(x)
+      } else {
+        result[key] = x
+      }
+      return result
+    }, {} as diffObject)
+}

--- a/cli/types/login.d.ts
+++ b/cli/types/login.d.ts
@@ -7,6 +7,19 @@ export {}
 
 declare module 'auth0' {
   interface ManagementClient<A = AppMetadata, U = UserMetadata> {
+    prompts: {
+      updateCustomTextByLanguage: (params: {
+        prompt: string
+        language: string
+        body: { [screen: string]: { [key: string]: string } }
+      }) => Promise<void>
+
+      getCustomTextByLanguage: (params: {
+        prompt: string
+        language: string
+      }) => Promise<{ [screen: string]: { [key: string]: string } }>
+    }
+
     branding: {
       getUniversalLoginTemplate: () => Promise<{ body: string }>
       setUniversalLoginTemplate: (

--- a/templates/custom-text.json
+++ b/templates/custom-text.json
@@ -1,0 +1,5 @@
+{
+  "signup": {
+    "auth0-users-validation": "Something went wrong, please try resetting your password or contacting support"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,9 +102,9 @@
   integrity sha512-9LSCqKbPxmOI294tcOnTMXnnfLcabgHw7ymmSqTNdDGiN7orBr/Gpi0G4r/tNktuRnZHF+QEW3LysXKfsVbN1A==
 
 "@types/auth0@^2.33.4":
-  version "2.33.4"
-  resolved "https://registry.yarnpkg.com/@types/auth0/-/auth0-2.33.4.tgz#5c1b7088107e823b3e262a9f5ef8debbaf35fce7"
-  integrity sha512-myVVdU9NVRvlFfiTBtqY7dEtfE2x3J/ziRliOYAKHE21CWBE3shOTMqnygXHwuEus2JuoY43xkJQLfCepo+N5w==
+  version "2.34.10"
+  resolved "https://registry.yarnpkg.com/@types/auth0/-/auth0-2.34.10.tgz#6ad475650f4723986ca11a02f4590a10e8245753"
+  integrity sha512-MgNPL7hEwWTPPmq9zin10kTTpdGvZLgpz7sBVK3YPyqasDGtuqJs6MiLkroKWhQq4W6lVFUQ52Wuo5QUomuOxA==
 
 "@types/bcrypt@^3.0.1":
   version "3.0.1"


### PR DESCRIPTION
If a user tries to sign up but already has a `people.person` entry in parfit gets an error message. Currently it just says `Something went wrong, please try again later`. In this case resetting the password would be the solution.
This affects all users that donated without creating an account or had an old account from the time before auth0 was introduced.

This PR adds a deploy script to change the `auth0-users-validation` error text to something more helpful.

See Auth0 documentation for more information:
https://auth0.com/docs/brand-and-customize/text-customization-new-universal-login/prompt-signup

### Before
<img width="470" alt="Screenshot 2022-01-25 at 18 07 11" src="https://user-images.githubusercontent.com/15565/151324762-2934b8c9-2239-4018-aa4f-004afcee5854.png">

### After
<img width="441" alt="Screenshot 2022-01-27 at 09 44 37" src="https://user-images.githubusercontent.com/15565/151324802-9f995be8-3352-4f14-9c2d-3613e71ed049.png">

