### PR TITLE
Improve error message on signup user validation

### DIFF
--- a/templates/custom-text.json
+++ b/templates/custom-text.json
@@ -1,5 +1,5 @@
 {
   "signup": {
-    "auth0-users-validation": "Something went wrong! You may already have an account, try logging in, reset your password, or contact support."
+    "auth0-users-validation": "Something went wrong! You may already have an account, try logging in, resetting your password, or contacting support."
   }
 }

--- a/templates/custom-text.json
+++ b/templates/custom-text.json
@@ -1,5 +1,5 @@
 {
   "signup": {
-    "auth0-users-validation": "Something went wrong, please try resetting your password or contacting support"
+    "auth0-users-validation": "Something went wrong! You may already have an account, try logging in, reset your password, or contact support."
   }
 }


### PR DESCRIPTION
We still get quite some intercom messages from users that get this error message and don't know what to do.
Usually they already have an account and try to sign up again.

Goal of this change is to make it clear what the next steps are and that users can solve their issues without contacting us first.