### PR TITLE
Show diffs in Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,13 @@ jobs:
       - name: Build CLI and rule definitions
         run: yarn build
 
+      - name: Diff changes
+        env:
+          TOKEN_NAMESPACE: ${{ secrets.TOKEN_NAMESPACE }}
+        run: yarn cli rules diff && yarn cli db diff && yarn cli login diff
+
       - name: Deploy
         env:
           TOKEN_NAMESPACE: ${{ secrets.TOKEN_NAMESPACE }}
-        run: yarn cli rules deploy && yarn cli db deploy && yarn cli login deploy
+        run:
+          yarn cli rules deploy && yarn cli db deploy && yarn cli login deploy

--- a/README.md
+++ b/README.md
@@ -565,3 +565,7 @@ username and password authentication.
 
 We use GitHub actions to auto-deploy these rules to the relevant Auth0 tenant
 when merging to `master` or `dev`.
+
+To check that deployment worked, check the workflow run of
+[Gitub Actions](https://github.com/centre-for-effective-altruism/auth0-rules/actions)
+and verify that the diffs are as expected.


### PR DESCRIPTION
This allows to review what changed during deployments and reduces the risk of accidentally change or corrupting the Auth0 configuration.

Note: This change was triggered by a recent incident. [Post-mortem here.](https://flower-puffin-b8d.notion.site/Pledge-signup-fails-with-Error-0daf218148e54def8eb451f87d0e534a)