### PR TITLE
Fix GWWC logo on login screen

### DIFF
--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -44,7 +44,7 @@
         width: 120px;
         height: 120px;
         margin: var(--logo-alignment);
-        background-image: url(https://images.ctfassets.net/dhpcfh1bs3p6/38hxh2plUIgaIIkE08CE2M/539859238d68f6b06373763c7633c836/GWWC-Color__1_.png?h=250);
+        background-image: url(https://www.givingwhatwecan.org/email/gwwc_logo.png);
         background-size: contain;
       }
     </style>

--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -41,11 +41,16 @@
       h1:after {
         content: "";
         display: block;
-        width: 120px;
-        height: 120px;
+        width: 100%;
+        height: 100px;
         margin: var(--logo-alignment);
         background-image: url(https://www.givingwhatwecan.org/email/gwwc_logo.png);
+<<<<<<< HEAD
         background-size: contain;
+=======
+        background-repeat: no-repeat !important;
+        background-size: contain !important;
+>>>>>>> 34dfb99 (Update GWWC image link)
       }
     </style>
     {% endif %}

--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -45,12 +45,8 @@
         height: 100px;
         margin: var(--logo-alignment);
         background-image: url(https://www.givingwhatwecan.org/email/gwwc_logo.png);
-<<<<<<< HEAD
-        background-size: contain;
-=======
         background-repeat: no-repeat !important;
         background-size: contain !important;
->>>>>>> 34dfb99 (Update GWWC image link)
       }
     </style>
     {% endif %}


### PR DESCRIPTION
Old link to the logo is not available anymore. This causes the login screen to render just whitespace
<img width="504" alt="Screenshot 2024-03-07 at 10 34 49" src="https://github.com/centre-for-effective-altruism/auth0-rules/assets/15565/e4fa4662-1267-4e11-8164-c0a91da40169">

Updating the link to a logo on the GWWC website fixes this:
<img width="527" alt="Screenshot 2024-03-07 at 10 34 23" src="https://github.com/centre-for-effective-altruism/auth0-rules/assets/15565/babc822b-647f-4488-82f4-af203de02d79">

(Note: I accidentally pushed to `dev` instead of a feature branch)