### PR TITLE
Update Sign Up screen text for GWWC

### DIFF
--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -28,7 +28,11 @@
         font-size: 0px !important;
       }
       header p:after {
+        {% if prompt.name contains "signup" %}
+        content: "Sign Up to Giving What We Can";
+        {% else %}
         content: "Log in to your Giving What We Can account";
+        {% endif %}
         text-indent: 0;
         display: block;
         font-size: 1rem;


### PR DESCRIPTION
Should solve the issue with the Sign Up screen showing "Log In" which confused a user

![image](https://github.com/centre-for-effective-altruism/auth0-rules/assets/6978200/7e8a787c-6731-4888-a13e-0395a14ded89)

[prompt.name](https://auth0.com/docs/customize/login-pages/universal-login/customize-templates#current-screen-information) should be available in these pages

@mordaroso Do you know how I can test this?