### PR TITLE
Upgrade to node 18

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 18
 
       # See https://www.maxivanov.io/github-actions-deploy-to-multiple-environments-from-single-workflow/
       - name: Set environment vars (staging)

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "typescript": "^4.2.4"
   },
   "engines": {
-    "node": "^14.11.x"
+    "node": "18.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/lodash": "^4.14.168",
     "@types/mongodb": "^3.6.12",
     "@types/mz": "^2.7.3",
-    "@types/node": "^14.14.37",
+    "@types/node": "18.11.0",
     "@types/pg": "^8.6.5",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",

--- a/scripts/rules/src/add-default-roles.ts
+++ b/scripts/rules/src/add-default-roles.ts
@@ -53,7 +53,7 @@ async function addDefaultRoles(
     const err = error as Error
     callback(
       new Error(
-        `Failed to set default role: ${err.message || JSON.stringify(error)}`
+        `Failed to set default role: ${err.message || JSON.stringify(err)}`
       )
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,10 +254,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.5.tgz#06caea822caf9e59d5034b695186ee74154d2802"
   integrity sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==
 
-"@types/node@^14.14.37":
-  version "14.18.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.23.tgz#70f5f20b0b1b38f696848c1d3647bb95694e615e"
-  integrity sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==
+"@types/node@18.11.0":
+  version "18.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.0.tgz#f38c7139247a1d619f6cc6f27b072606af7c289d"
+  integrity sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
I'm in the process of migrating Rules to Actions, and this [this library](https://www.npmjs.com/package/auth0-actions/v/0.1.1) that has some useful types requires node 18.

I have tested `yarn cli [rules|db|login] diff` and `yarn cli [rules|db|login] deploy` on the local tenant and it worked as expected.