### PR TITLE
Migrate remaining Rules to Actions

### DIFF
--- a/cli/manifests.ts
+++ b/cli/manifests.ts
@@ -119,6 +119,30 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
       return { defaultRoles }
     },
   },
+  {
+    name: 'Filter scopes',
+    file: 'filter-scopes',
+    enabled: true,
+    trigger: 'post-login',
+    triggerVersion: 'v3',
+    getData: async () => {
+      const applicationNames = [
+        'EA Funds',
+        'Giving What We Can',
+        'Parfit Admin',
+      ]
+      const Clients = await getAllClients()
+      const whitelist = Clients.filter(isValidClient)
+        .filter((Client) => applicationNames.includes(Client.name))
+        .map((Client) =>
+          getCommentValue({
+            applicationName: Client.name,
+            value: Client.client_id,
+          })
+        )
+      return { whitelist }
+    },
+  },
 ]
 
 /**

--- a/cli/manifests.ts
+++ b/cli/manifests.ts
@@ -93,11 +93,15 @@ export const RULE_MANIFEST: RuleDefinition[] = [
 
 export const ACTION_MANIFEST: ActionDefinition[] = [
   {
-    name: 'Log Context',
-    file: 'log-context',
-    enabled: false,
+    name: 'Add email to access token',
+    file: 'email-to-access-token',
+    enabled: true,
     trigger: 'post-login',
     triggerVersion: 'v3',
+    getData: () => {
+      const namespace = process.env.TOKEN_NAMESPACE
+      return { namespace }
+    },
   },
   {
     name: 'Add Default Role To All Users',
@@ -142,6 +146,13 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
         )
       return { whitelist }
     },
+  },
+  {
+    name: 'Log Context',
+    file: 'log-context',
+    enabled: false,
+    trigger: 'post-login',
+    triggerVersion: 'v3',
   },
 ]
 

--- a/cli/manifests.ts
+++ b/cli/manifests.ts
@@ -124,27 +124,52 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
     },
   },
   {
-    name: 'Filter scopes',
-    file: 'filter-scopes',
+    name: 'Manage scopes',
+    file: 'manage-scopes',
     enabled: true,
     trigger: 'post-login',
     triggerVersion: 'v3',
     getData: async () => {
-      const applicationNames = [
+      // Get token namespace
+      const namespace = process.env.TOKEN_NAMESPACE
+
+      const allowAllScopesApplicationNames = [
         'EA Funds',
         'Giving What We Can',
         'Parfit Admin',
       ]
+
+      const scopesToIdTokenApplicationNames = ['Giving What We Can']
+
       const Clients = await getAllClients()
-      const whitelist = Clients.filter(isValidClient)
-        .filter((Client) => applicationNames.includes(Client.name))
+      const validClients = Clients.filter(isValidClient)
+      const allowAllScopesWhitelist = validClients
+        .filter((Client) =>
+          allowAllScopesApplicationNames.includes(Client.name)
+        )
         .map((Client) =>
           getCommentValue({
             applicationName: Client.name,
             value: Client.client_id,
           })
         )
-      return { whitelist }
+
+      const addScopesToIdTokenApplications = Clients.filter(isValidClient)
+        .filter((Client) =>
+          scopesToIdTokenApplicationNames.includes(Client.name)
+        )
+        .map((Client) =>
+          getCommentValue({
+            applicationName: Client.name,
+            value: Client.client_id,
+          })
+        )
+
+      return {
+        allowAllScopesWhitelist,
+        addScopesToIdTokenApplications,
+        namespace,
+      }
     },
   },
   {

--- a/scripts/actions/src/add-default-roles.ts
+++ b/scripts/actions/src/add-default-roles.ts
@@ -11,7 +11,7 @@ exports.onExecutePostLogin = async (
   api: DefaultPostLoginApi
 ) => {
   // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules). Separate values are for dev, staging and prod
   const rules = api.rules
   if (
     rules.wasExecuted('rul_bnNiRxFsMNMFESXI') ||

--- a/scripts/actions/src/add-default-roles.ts
+++ b/scripts/actions/src/add-default-roles.ts
@@ -32,7 +32,7 @@ exports.onExecutePostLogin = async (
       scope: 'read:users update:users read:roles',
     })
 
-    const params = { id: event.user!.user_id }
+    const params = { id: event.user.user_id }
     const data = { roles: DEFAULT_ROLES }
 
     // If the user is brand new there's no way that they have that role applied,
@@ -43,7 +43,7 @@ exports.onExecutePostLogin = async (
     }
 
     // Otherwise we need to check the roles currently assigned to the user
-    const roles = await management.users.getRoles({ id: event.user!.user_id })
+    const roles = await management.users.getRoles({ id: event.user.user_id })
     const roleIds = roles.data.map((role: { id: string }) => role.id)
 
     if (!DEFAULT_ROLES.every((defaultRole) => roleIds.includes(defaultRole))) {

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -12,7 +12,7 @@ exports.onExecutePostLogin = async (
   api: DefaultPostLoginApi
 ) => {
   // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules). Separate values are for dev, staging and prod
   const rules = api.rules
   if (
     rules.wasExecuted('rul_p0EQTFpeLGeLw1DP') ||

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -22,14 +22,10 @@ exports.onExecutePostLogin = async (
     return
   }
 
-  if (!event.authorization) return
-
   const namespace = TEMPLATE_DATA.namespace
   const email = event.user!.email
   const emailVerified = event.user!.email_verified
 
-  if (event.authorization) {
-    api.accessToken.setCustomClaim(`${namespace}/email`, email)
-    api.accessToken.setCustomClaim(`${namespace}/email_verified`, emailVerified)
-  }
+  api.accessToken.setCustomClaim(`${namespace}/email`, email)
+  api.accessToken.setCustomClaim(`${namespace}/email_verified`, emailVerified)
 }

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -1,0 +1,30 @@
+import {
+  DefaultPostLoginApi,
+  DefaultPostLoginEvent,
+} from '../types/auth0-actions'
+
+/**
+ * Some server-side applications need access to the user's email address. This
+ * rule adds the user's email address and verification status to the Access Token
+ */
+exports.onExecutePostLogin = async (
+  event: DefaultPostLoginEvent,
+  api: DefaultPostLoginApi
+) => {
+  // Skip if the analogous Rule was executed first. You can get this ID from the Rules
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules)
+  if (api.rules.wasExecuted('rul_p0EQTFpeLGeLw1DP')) {
+    return
+  }
+
+  if (!event.authorization) return
+
+  const namespace = TEMPLATE_DATA.namespace
+  const email = event.user!.email
+  const emailVerified = event.user!.email_verified
+
+  if (event.authorization) {
+    api.accessToken.setCustomClaim(`${namespace}/email`, email)
+    api.accessToken.setCustomClaim(`${namespace}/email_verified`, emailVerified)
+  }
+}

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -11,9 +11,14 @@ exports.onExecutePostLogin = async (
   event: DefaultPostLoginEvent,
   api: DefaultPostLoginApi
 ) => {
-  // Skip if the analogous Rule was executed first. You can get this ID from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules)
-  if (api.rules.wasExecuted('rul_p0EQTFpeLGeLw1DP')) {
+  // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  const rules = api.rules
+  if (
+    rules.wasExecuted('rul_p0EQTFpeLGeLw1DP') ||
+    rules.wasExecuted('rul_f067BwtcAm0kJ4DN') ||
+    rules.wasExecuted('rul_8l8h1CJpOp1tRVRP')
+  ) {
     return
   }
 

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -23,8 +23,8 @@ exports.onExecutePostLogin = async (
   }
 
   const namespace = TEMPLATE_DATA.namespace
-  const email = event.user!.email
-  const emailVerified = event.user!.email_verified
+  const email = event.user.email
+  const emailVerified = event.user.email_verified
 
   api.accessToken.setCustomClaim(`${namespace}/email`, email)
   api.accessToken.setCustomClaim(`${namespace}/email_verified`, emailVerified)

--- a/scripts/actions/src/filter-scopes.ts
+++ b/scripts/actions/src/filter-scopes.ts
@@ -32,9 +32,14 @@ exports.onExecutePostLogin = async (
   event: DefaultPostLoginEvent,
   api: DefaultPostLoginApi
 ) => {
-  // Skip if the analogous Rule was executed first. You can get this ID from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules)
-  if (api.rules.wasExecuted('rul_iFouQc7sxIAebmG9')) {
+  // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  const rules = api.rules
+  if (
+    rules.wasExecuted('rul_iFouQc7sxIAebmG9') ||
+    rules.wasExecuted('rul_ytSv3P9tcJqlXDLG') ||
+    rules.wasExecuted('rul_Bwm6gas2fMgn02xq')
+  ) {
     return
   }
 

--- a/scripts/actions/src/filter-scopes.ts
+++ b/scripts/actions/src/filter-scopes.ts
@@ -1,0 +1,88 @@
+import {
+  DefaultPostLoginApi,
+  DefaultPostLoginEvent,
+} from '../types/auth0-actions'
+import { ManagementClient, Permission } from 'auth0'
+
+const auth0Sdk = require('auth0')
+
+// basic OAuth 2.0 scopes that any client is allowed to request
+const DEFAULT_SCOPES = ['openid', 'profile', 'email', 'offline_access']
+// whitelist of scopes accessible to applications that aren't on the application whitelist
+// (currently empty, but we may expand it in future...)
+const SCOPE_WHITELIST: string[] = []
+
+exports.onExecutePostLogin = async (
+  event: DefaultPostLoginEvent,
+  api: DefaultPostLoginApi
+) => {
+  // Skip if the analogous Rule was executed first. You can get this ID from the Rules
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules)
+  if (api.rules.wasExecuted('rul_iFouQc7sxIAebmG9')) {
+    return
+  }
+
+  // Whitelist of applications that can access the full set of scopes
+  const applicationWhitelist: string[] = TEMPLATE_DATA.whitelist
+
+  // Set up a management client so that we can read the user's full set of permissions
+  const ManagementClient = auth0Sdk.ManagementClient
+  const management: ManagementClient = new ManagementClient({
+    domain: event.secrets.AUTH0_DOMAIN,
+    clientId: event.secrets.AUTH0_CLIENT_ID,
+    clientSecret: event.secrets.AUTH0_CLIENT_SECRET,
+    scope: 'read:roles',
+  })
+
+  // Function to page through all of a user's permissions
+  const RESULTS_PER_PAGE = 20 // max is 25 (unconfirmed)
+  async function getUserPermissions(
+    userId: string,
+    page = 0
+  ): Promise<Permission[]> {
+    const results = (
+      await management.users.getPermissions({
+        id: userId,
+        page,
+        per_page: RESULTS_PER_PAGE,
+      })
+    ).data
+    // If we're on the last page, get out of here
+    if (results.length < RESULTS_PER_PAGE) return results
+    // Otherwise, get the next set of results too
+    const nextResults = await getUserPermissions(userId, page + 1)
+    return [...results, ...nextResults]
+  }
+
+  // get the user's canonical set of permissions
+  const userPermissions = await getUserPermissions(event.user?.user_id!)
+
+  const userScopes = userPermissions.map(
+    (permissionObj) => permissionObj.permission_name!
+  )
+
+  // scopes that the client application has requested on behalf of the user
+  const requestedScopes: string[] = event.transaction?.requested_scopes || []
+
+  // get a list of the whitelisted scopes that the user has access to
+  const allowedUserScopes = SCOPE_WHITELIST.filter((scope) =>
+    userScopes.includes(scope)
+  )
+
+  // final list of all allowed scopes
+  const allowedScopes = applicationWhitelist.includes(event.client?.clientId!)
+    ? [...DEFAULT_SCOPES, ...userScopes]
+    : [...DEFAULT_SCOPES, ...allowedUserScopes]
+
+  // final list of scopes to add to the access token, built by diffing
+  // the list of allowed scopes against the requested scopes
+  const finalScopes = allowedScopes.filter((scope) =>
+    requestedScopes.includes(scope)
+  )
+
+  const removedScopes = requestedScopes.filter((s) => !finalScopes.includes(s))
+
+  for (const scope of removedScopes) {
+    api.accessToken.removeScope(scope)
+  }
+}

--- a/scripts/actions/src/log-context.ts
+++ b/scripts/actions/src/log-context.ts
@@ -14,7 +14,7 @@ exports.onExecutePostLogin = async (
   api: DefaultPostLoginApi
 ) => {
   // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules). Separate values are for dev, staging and prod
   const rules = api.rules
   if (
     rules.wasExecuted('rul_3YxacLKiymV7HNa5') ||

--- a/scripts/actions/src/manage-scopes.ts
+++ b/scripts/actions/src/manage-scopes.ts
@@ -50,7 +50,7 @@ exports.onExecutePostLogin = async (
   api: DefaultPostLoginApi
 ) => {
   // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules). Separate values are for dev, staging and prod
   const rules = api.rules
   if (
     rules.wasExecuted('rul_iFouQc7sxIAebmG9') ||

--- a/scripts/actions/src/manage-scopes.ts
+++ b/scripts/actions/src/manage-scopes.ts
@@ -60,8 +60,8 @@ exports.onExecutePostLogin = async (
     return
   }
 
-  const userId = event.user?.user_id!
-  const clientId = event.client?.clientId!
+  const userId = event.user.user_id
+  const clientId = event.client.clientId
 
   // Whitelist of applications that can access the full set of scopes
   const allowAllScopesWhitelist: string[] =

--- a/scripts/actions/src/manage-scopes.ts
+++ b/scripts/actions/src/manage-scopes.ts
@@ -99,9 +99,9 @@ exports.onExecutePostLogin = async (
   // get the user's canonical set of permissions
   const userPermissions = await getUserPermissions(userId)
 
-  const userScopes = userPermissions.map(
-    (permissionObj) => permissionObj.permission_name!
-  )
+  const userScopes = userPermissions
+    .map((permissionObj) => permissionObj.permission_name)
+    .filter((name): name is string => !!name)
 
   // scopes that the client application has requested on behalf of the user
   const requestedScopes: string[] =

--- a/scripts/actions/types/auth0-actions.d.ts
+++ b/scripts/actions/types/auth0-actions.d.ts
@@ -1,4 +1,4 @@
-import { PostLoginEvent, PostLoginApi } from 'auth0-actions'
+import { PostLoginEvent, PostLoginApi, UserBase, Client } from 'auth0-actions'
 
 export interface ActionsDefaultSecrets {
   AUTH0_DOMAIN: string
@@ -12,6 +12,9 @@ export interface ActionsDefaultSecrets {
 export interface DefaultPostLoginEvent
   extends PostLoginEvent<ActionsDefaultSecrets, any, any, any> {
   secrets: ActionsDefaultSecrets
+  // `user` and `client` are not optional according to https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/event-object
+  user: UserBase<any, any>
+  client: Client<any>
 }
 
 export interface DefaultPostLoginApi extends PostLoginApi {


### PR DESCRIPTION
This migrates the remaining Rules to Actions, these are:
- email-to-access-token
- filter-scopes
- add-scopes-to-id-token

`filter-scopes` and `add-scopes-to-id-token` are now combined into one action, because there is no longer a way to get the list of scopes from the `accessToken`, so we instead infer the list from the scopes that we have allowed after the `filter-scopes` logic runs.

How to test each Action (using the EA Forum dev environment):

**email-to-access-token**

`accessToken` is a JWT, which can be decoded using [jwt.io](https://jwt.io) to view the properties it contains. It will be encrypted unless you include an `audience` parameter in the request though ([see here](https://community.auth0.com/t/why-access-token-is-not-a-jwt-opaque-token/31028)). You can add an audience to the authentication requests:

`packages/lesswrong/server/authentication/auth0.ts:156`:
```typescript
   const grant = await client.passwordGrant({
      username: email,
      password,
      realm: getAuth0Connection(),
      scope: AUTH0_SCOPE,
      audience: 'https://effectivealtruism-local.auth0.com/api/v2/'
    });
```

`packages/lesswrong/server/authenticationMiddlewares.ts:581`:
```typescript
    passport.authenticate('auth0', {
      scope: AUTH0_SCOPE,
      audience: 'https://effectivealtruism-local.auth0.com/api/v2/',
      ...extraParams
    } as AuthenticateOptions)(req, res, next)
```

If you then log the access token and put it into [jwt.io](https://jwt.io), it should look like this (include the `https://parfit.effectivealtruism.org/email` and `https://parfit.effectivealtruism.org/email_verified` fields)
```json
{
  "https://parfit.effectivealtruism.org/email": "w.howard256@gmail.com",
  "https://parfit.effectivealtruism.org/email_verified": true,
  ...
}
```
And this should be the same whether using the Rule or the Action

**filter-scopes**

Logging in on the Forum requests the scopes `'openid', 'profile', 'email', 'offline_access'`, which is the same as the default allowed scopes in `filter-scopes`. You can try removing one of the allowed scopes in `filter-scopes` (e.g. `email`), you can then check that this has blocked the request for that scope by:
- Inspecting the access token (in [jwt.io](https://jwt.io) as above)
- Using the `/userinfo` endpoint with the access token returned. It should exclude the users email in the response if the `email` scope is blocked

`/userinfo` endpoint:
```
curl --request GET \
  --url 'https://effectivealtruism-local.auth0.com/userinfo' \
  --header 'Authorization: Bearer ACCESS_TOKEN' \
  --header 'Content-Type: application/json'
```

**add-scopes-to-id-token**

When logging in with username/password you can log the `grant` object, which contains the `id_token`:

`packages/lesswrong/server/authentication/auth0.ts:149`:
```typescript
  async loginUser(email: string, password: string): Promise<string | null> {
    const client = this.getAuthClient();
    const grant = await client.passwordGrant({
      username: email,
      password,
      realm: getAuth0Connection(),
      scope: AUTH0_SCOPE,
      audience: 'https://effectivealtruism-local.auth0.com/api/v2/'
    });
    console.log({grant})
    return grant?.access_token ?? null;
  }
```

You can then again decode this with [jwt.io](https://jwt.io) and confirm it contains the `"https://parfit.effectivealtruism.org/scope": '...'` field