### PR TITLE
Deploy migration to Actions for remaining Rules

### DIFF
--- a/cli/manifests.ts
+++ b/cli/manifests.ts
@@ -119,6 +119,30 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
       return { defaultRoles }
     },
   },
+  {
+    name: 'Filter scopes',
+    file: 'filter-scopes',
+    enabled: true,
+    trigger: 'post-login',
+    triggerVersion: 'v3',
+    getData: async () => {
+      const applicationNames = [
+        'EA Funds',
+        'Giving What We Can',
+        'Parfit Admin',
+      ]
+      const Clients = await getAllClients()
+      const whitelist = Clients.filter(isValidClient)
+        .filter((Client) => applicationNames.includes(Client.name))
+        .map((Client) =>
+          getCommentValue({
+            applicationName: Client.name,
+            value: Client.client_id,
+          })
+        )
+      return { whitelist }
+    },
+  },
 ]
 
 /**

--- a/cli/manifests.ts
+++ b/cli/manifests.ts
@@ -93,11 +93,15 @@ export const RULE_MANIFEST: RuleDefinition[] = [
 
 export const ACTION_MANIFEST: ActionDefinition[] = [
   {
-    name: 'Log Context',
-    file: 'log-context',
-    enabled: false,
+    name: 'Add email to access token',
+    file: 'email-to-access-token',
+    enabled: true,
     trigger: 'post-login',
     triggerVersion: 'v3',
+    getData: () => {
+      const namespace = process.env.TOKEN_NAMESPACE
+      return { namespace }
+    },
   },
   {
     name: 'Add Default Role To All Users',
@@ -142,6 +146,13 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
         )
       return { whitelist }
     },
+  },
+  {
+    name: 'Log Context',
+    file: 'log-context',
+    enabled: false,
+    trigger: 'post-login',
+    triggerVersion: 'v3',
   },
 ]
 

--- a/cli/manifests.ts
+++ b/cli/manifests.ts
@@ -124,27 +124,52 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
     },
   },
   {
-    name: 'Filter scopes',
-    file: 'filter-scopes',
+    name: 'Manage scopes',
+    file: 'manage-scopes',
     enabled: true,
     trigger: 'post-login',
     triggerVersion: 'v3',
     getData: async () => {
-      const applicationNames = [
+      // Get token namespace
+      const namespace = process.env.TOKEN_NAMESPACE
+
+      const allowAllScopesApplicationNames = [
         'EA Funds',
         'Giving What We Can',
         'Parfit Admin',
       ]
+
+      const scopesToIdTokenApplicationNames = ['Giving What We Can']
+
       const Clients = await getAllClients()
-      const whitelist = Clients.filter(isValidClient)
-        .filter((Client) => applicationNames.includes(Client.name))
+      const validClients = Clients.filter(isValidClient)
+      const allowAllScopesWhitelist = validClients
+        .filter((Client) =>
+          allowAllScopesApplicationNames.includes(Client.name)
+        )
         .map((Client) =>
           getCommentValue({
             applicationName: Client.name,
             value: Client.client_id,
           })
         )
-      return { whitelist }
+
+      const addScopesToIdTokenApplications = Clients.filter(isValidClient)
+        .filter((Client) =>
+          scopesToIdTokenApplicationNames.includes(Client.name)
+        )
+        .map((Client) =>
+          getCommentValue({
+            applicationName: Client.name,
+            value: Client.client_id,
+          })
+        )
+
+      return {
+        allowAllScopesWhitelist,
+        addScopesToIdTokenApplications,
+        namespace,
+      }
     },
   },
   {

--- a/scripts/actions/src/add-default-roles.ts
+++ b/scripts/actions/src/add-default-roles.ts
@@ -11,7 +11,7 @@ exports.onExecutePostLogin = async (
   api: DefaultPostLoginApi
 ) => {
   // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules). Separate values are for dev, staging and prod
   const rules = api.rules
   if (
     rules.wasExecuted('rul_bnNiRxFsMNMFESXI') ||

--- a/scripts/actions/src/add-default-roles.ts
+++ b/scripts/actions/src/add-default-roles.ts
@@ -32,7 +32,7 @@ exports.onExecutePostLogin = async (
       scope: 'read:users update:users read:roles',
     })
 
-    const params = { id: event.user!.user_id }
+    const params = { id: event.user.user_id }
     const data = { roles: DEFAULT_ROLES }
 
     // If the user is brand new there's no way that they have that role applied,
@@ -43,7 +43,7 @@ exports.onExecutePostLogin = async (
     }
 
     // Otherwise we need to check the roles currently assigned to the user
-    const roles = await management.users.getRoles({ id: event.user!.user_id })
+    const roles = await management.users.getRoles({ id: event.user.user_id })
     const roleIds = roles.data.map((role: { id: string }) => role.id)
 
     if (!DEFAULT_ROLES.every((defaultRole) => roleIds.includes(defaultRole))) {

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -12,7 +12,7 @@ exports.onExecutePostLogin = async (
   api: DefaultPostLoginApi
 ) => {
   // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules). Separate values are for dev, staging and prod
   const rules = api.rules
   if (
     rules.wasExecuted('rul_p0EQTFpeLGeLw1DP') ||

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -22,14 +22,10 @@ exports.onExecutePostLogin = async (
     return
   }
 
-  if (!event.authorization) return
-
   const namespace = TEMPLATE_DATA.namespace
   const email = event.user!.email
   const emailVerified = event.user!.email_verified
 
-  if (event.authorization) {
-    api.accessToken.setCustomClaim(`${namespace}/email`, email)
-    api.accessToken.setCustomClaim(`${namespace}/email_verified`, emailVerified)
-  }
+  api.accessToken.setCustomClaim(`${namespace}/email`, email)
+  api.accessToken.setCustomClaim(`${namespace}/email_verified`, emailVerified)
 }

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -1,0 +1,30 @@
+import {
+  DefaultPostLoginApi,
+  DefaultPostLoginEvent,
+} from '../types/auth0-actions'
+
+/**
+ * Some server-side applications need access to the user's email address. This
+ * rule adds the user's email address and verification status to the Access Token
+ */
+exports.onExecutePostLogin = async (
+  event: DefaultPostLoginEvent,
+  api: DefaultPostLoginApi
+) => {
+  // Skip if the analogous Rule was executed first. You can get this ID from the Rules
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules)
+  if (api.rules.wasExecuted('rul_p0EQTFpeLGeLw1DP')) {
+    return
+  }
+
+  if (!event.authorization) return
+
+  const namespace = TEMPLATE_DATA.namespace
+  const email = event.user!.email
+  const emailVerified = event.user!.email_verified
+
+  if (event.authorization) {
+    api.accessToken.setCustomClaim(`${namespace}/email`, email)
+    api.accessToken.setCustomClaim(`${namespace}/email_verified`, emailVerified)
+  }
+}

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -11,9 +11,14 @@ exports.onExecutePostLogin = async (
   event: DefaultPostLoginEvent,
   api: DefaultPostLoginApi
 ) => {
-  // Skip if the analogous Rule was executed first. You can get this ID from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules)
-  if (api.rules.wasExecuted('rul_p0EQTFpeLGeLw1DP')) {
+  // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  const rules = api.rules
+  if (
+    rules.wasExecuted('rul_p0EQTFpeLGeLw1DP') ||
+    rules.wasExecuted('rul_f067BwtcAm0kJ4DN') ||
+    rules.wasExecuted('rul_8l8h1CJpOp1tRVRP')
+  ) {
     return
   }
 

--- a/scripts/actions/src/email-to-access-token.ts
+++ b/scripts/actions/src/email-to-access-token.ts
@@ -23,8 +23,8 @@ exports.onExecutePostLogin = async (
   }
 
   const namespace = TEMPLATE_DATA.namespace
-  const email = event.user!.email
-  const emailVerified = event.user!.email_verified
+  const email = event.user.email
+  const emailVerified = event.user.email_verified
 
   api.accessToken.setCustomClaim(`${namespace}/email`, email)
   api.accessToken.setCustomClaim(`${namespace}/email_verified`, emailVerified)

--- a/scripts/actions/src/filter-scopes.ts
+++ b/scripts/actions/src/filter-scopes.ts
@@ -32,9 +32,14 @@ exports.onExecutePostLogin = async (
   event: DefaultPostLoginEvent,
   api: DefaultPostLoginApi
 ) => {
-  // Skip if the analogous Rule was executed first. You can get this ID from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules)
-  if (api.rules.wasExecuted('rul_iFouQc7sxIAebmG9')) {
+  // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  const rules = api.rules
+  if (
+    rules.wasExecuted('rul_iFouQc7sxIAebmG9') ||
+    rules.wasExecuted('rul_ytSv3P9tcJqlXDLG') ||
+    rules.wasExecuted('rul_Bwm6gas2fMgn02xq')
+  ) {
     return
   }
 

--- a/scripts/actions/src/filter-scopes.ts
+++ b/scripts/actions/src/filter-scopes.ts
@@ -1,0 +1,88 @@
+import {
+  DefaultPostLoginApi,
+  DefaultPostLoginEvent,
+} from '../types/auth0-actions'
+import { ManagementClient, Permission } from 'auth0'
+
+const auth0Sdk = require('auth0')
+
+// basic OAuth 2.0 scopes that any client is allowed to request
+const DEFAULT_SCOPES = ['openid', 'profile', 'email', 'offline_access']
+// whitelist of scopes accessible to applications that aren't on the application whitelist
+// (currently empty, but we may expand it in future...)
+const SCOPE_WHITELIST: string[] = []
+
+exports.onExecutePostLogin = async (
+  event: DefaultPostLoginEvent,
+  api: DefaultPostLoginApi
+) => {
+  // Skip if the analogous Rule was executed first. You can get this ID from the Rules
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules)
+  if (api.rules.wasExecuted('rul_iFouQc7sxIAebmG9')) {
+    return
+  }
+
+  // Whitelist of applications that can access the full set of scopes
+  const applicationWhitelist: string[] = TEMPLATE_DATA.whitelist
+
+  // Set up a management client so that we can read the user's full set of permissions
+  const ManagementClient = auth0Sdk.ManagementClient
+  const management: ManagementClient = new ManagementClient({
+    domain: event.secrets.AUTH0_DOMAIN,
+    clientId: event.secrets.AUTH0_CLIENT_ID,
+    clientSecret: event.secrets.AUTH0_CLIENT_SECRET,
+    scope: 'read:roles',
+  })
+
+  // Function to page through all of a user's permissions
+  const RESULTS_PER_PAGE = 20 // max is 25 (unconfirmed)
+  async function getUserPermissions(
+    userId: string,
+    page = 0
+  ): Promise<Permission[]> {
+    const results = (
+      await management.users.getPermissions({
+        id: userId,
+        page,
+        per_page: RESULTS_PER_PAGE,
+      })
+    ).data
+    // If we're on the last page, get out of here
+    if (results.length < RESULTS_PER_PAGE) return results
+    // Otherwise, get the next set of results too
+    const nextResults = await getUserPermissions(userId, page + 1)
+    return [...results, ...nextResults]
+  }
+
+  // get the user's canonical set of permissions
+  const userPermissions = await getUserPermissions(event.user?.user_id!)
+
+  const userScopes = userPermissions.map(
+    (permissionObj) => permissionObj.permission_name!
+  )
+
+  // scopes that the client application has requested on behalf of the user
+  const requestedScopes: string[] = event.transaction?.requested_scopes || []
+
+  // get a list of the whitelisted scopes that the user has access to
+  const allowedUserScopes = SCOPE_WHITELIST.filter((scope) =>
+    userScopes.includes(scope)
+  )
+
+  // final list of all allowed scopes
+  const allowedScopes = applicationWhitelist.includes(event.client?.clientId!)
+    ? [...DEFAULT_SCOPES, ...userScopes]
+    : [...DEFAULT_SCOPES, ...allowedUserScopes]
+
+  // final list of scopes to add to the access token, built by diffing
+  // the list of allowed scopes against the requested scopes
+  const finalScopes = allowedScopes.filter((scope) =>
+    requestedScopes.includes(scope)
+  )
+
+  const removedScopes = requestedScopes.filter((s) => !finalScopes.includes(s))
+
+  for (const scope of removedScopes) {
+    api.accessToken.removeScope(scope)
+  }
+}

--- a/scripts/actions/src/log-context.ts
+++ b/scripts/actions/src/log-context.ts
@@ -14,7 +14,7 @@ exports.onExecutePostLogin = async (
   api: DefaultPostLoginApi
 ) => {
   // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules). Separate values are for dev, staging and prod
   const rules = api.rules
   if (
     rules.wasExecuted('rul_3YxacLKiymV7HNa5') ||

--- a/scripts/actions/src/manage-scopes.ts
+++ b/scripts/actions/src/manage-scopes.ts
@@ -50,7 +50,7 @@ exports.onExecutePostLogin = async (
   api: DefaultPostLoginApi
 ) => {
   // Skip if the analogous Rule was executed first. You can get these IDs from the Rules
-  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules), separate values are for dev, staging and prod
+  // page in the Auth0 dashboard (https://manage.auth0.com/#/rules). Separate values are for dev, staging and prod
   const rules = api.rules
   if (
     rules.wasExecuted('rul_iFouQc7sxIAebmG9') ||

--- a/scripts/actions/src/manage-scopes.ts
+++ b/scripts/actions/src/manage-scopes.ts
@@ -60,8 +60,8 @@ exports.onExecutePostLogin = async (
     return
   }
 
-  const userId = event.user?.user_id!
-  const clientId = event.client?.clientId!
+  const userId = event.user.user_id
+  const clientId = event.client.clientId
 
   // Whitelist of applications that can access the full set of scopes
   const allowAllScopesWhitelist: string[] =

--- a/scripts/actions/src/manage-scopes.ts
+++ b/scripts/actions/src/manage-scopes.ts
@@ -99,9 +99,9 @@ exports.onExecutePostLogin = async (
   // get the user's canonical set of permissions
   const userPermissions = await getUserPermissions(userId)
 
-  const userScopes = userPermissions.map(
-    (permissionObj) => permissionObj.permission_name!
-  )
+  const userScopes = userPermissions
+    .map((permissionObj) => permissionObj.permission_name)
+    .filter((name): name is string => !!name)
 
   // scopes that the client application has requested on behalf of the user
   const requestedScopes: string[] =

--- a/scripts/actions/types/auth0-actions.d.ts
+++ b/scripts/actions/types/auth0-actions.d.ts
@@ -1,4 +1,4 @@
-import { PostLoginEvent, PostLoginApi } from 'auth0-actions'
+import { PostLoginEvent, PostLoginApi, UserBase, Client } from 'auth0-actions'
 
 export interface ActionsDefaultSecrets {
   AUTH0_DOMAIN: string
@@ -12,6 +12,9 @@ export interface ActionsDefaultSecrets {
 export interface DefaultPostLoginEvent
   extends PostLoginEvent<ActionsDefaultSecrets, any, any, any> {
   secrets: ActionsDefaultSecrets
+  // `user` and `client` are not optional according to https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/event-object
+  user: UserBase<any, any>
+  client: Client<any>
 }
 
 export interface DefaultPostLoginApi extends PostLoginApi {


### PR DESCRIPTION
Deploys:
- #49 

Once this is deployed, the rules will still be active. To enable the Actions, we will need to disable the Rules from [here](https://manage.auth0.com/dashboard/us/effectivealtruism/rules), the corresponding action will take over once a rule is turned off. It's important to do this in reverse order to keep the overall order of the logic the same (because actions run after rules)