### PR TITLE
Fix mistyping in auth0-actions: clientId -> client_id

### DIFF
--- a/scripts/actions/src/manage-scopes.ts
+++ b/scripts/actions/src/manage-scopes.ts
@@ -61,7 +61,7 @@ exports.onExecutePostLogin = async (
   }
 
   const userId = event.user.user_id
-  const clientId = event.client.clientId
+  const clientId = event.client.client_id
 
   // Whitelist of applications that can access the full set of scopes
   const allowAllScopesWhitelist: string[] =

--- a/scripts/actions/types/auth0-actions.d.ts
+++ b/scripts/actions/types/auth0-actions.d.ts
@@ -9,12 +9,17 @@ export interface ActionsDefaultSecrets {
 // auth0-actions doesn't have all the types completely correct, use the modified types below.
 // TODO upgrade to an officially supported type package once one becomes available
 
+// `client_id` is incorrectly typed as `clientId` (see https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/event-object)
+interface CorrectlyTypedClient<T> extends Omit<Client<T>, 'clientId'> {
+  client_id: string
+}
+
 export interface DefaultPostLoginEvent
   extends PostLoginEvent<ActionsDefaultSecrets, any, any, any> {
   secrets: ActionsDefaultSecrets
   // `user` and `client` are not optional according to https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/event-object
   user: UserBase<any, any>
-  client: Client<any>
+  client: CorrectlyTypedClient<any>
 }
 
 export interface DefaultPostLoginApi extends PostLoginApi {


### PR DESCRIPTION
This was causing login to fail on GWWC, because `clientId` was undefined, so GWWC wasn't found in `allowAllScopesWhitelist`. This resulted in only the default scopes being allowed

This is the correct reference for the type of the `event` object: https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/event-object