### PR TITLE
Remove Giving What We Can related code

### DIFF
--- a/cli/manifests.ts
+++ b/cli/manifests.ts
@@ -31,12 +31,7 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
     trigger: 'post-login',
     triggerVersion: 'v3',
     getData: async () => {
-      const defaultRoleNames = [
-        'User-Basic-Role',
-        'Parfit User',
-        'EA Funds User',
-        'Giving What We Can User',
-      ]
+      const defaultRoleNames = ['User-Basic-Role', 'EA Funds User']
       const Roles = await getAllRoles()
       const defaultRoles = Roles.filter(isValidRole)
         .filter((Role) => defaultRoleNames.includes(Role.name))
@@ -54,13 +49,7 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
       // Get token namespace
       const namespace = process.env.TOKEN_NAMESPACE
 
-      const allowAllScopesApplicationNames = [
-        'EA Funds',
-        'Giving What We Can',
-        'Parfit Admin',
-      ]
-
-      const scopesToIdTokenApplicationNames = ['Giving What We Can']
+      const allowAllScopesApplicationNames = ['EA Funds']
 
       const Clients = await getAllClients()
       const validClients = Clients.filter(isValidClient)
@@ -75,20 +64,8 @@ export const ACTION_MANIFEST: ActionDefinition[] = [
           })
         )
 
-      const addScopesToIdTokenApplications = Clients.filter(isValidClient)
-        .filter((Client) =>
-          scopesToIdTokenApplicationNames.includes(Client.name)
-        )
-        .map((Client) =>
-          getCommentValue({
-            applicationName: Client.name,
-            value: Client.client_id,
-          })
-        )
-
       return {
         allowAllScopesWhitelist,
-        addScopesToIdTokenApplications,
         namespace,
       }
     },

--- a/scripts/actions/src/manage-scopes.ts
+++ b/scripts/actions/src/manage-scopes.ts
@@ -119,13 +119,4 @@ exports.onExecutePostLogin = async (
   for (const scope of removedScopes) {
     api.accessToken.removeScope(scope)
   }
-
-  // Add scopes to id token
-  const finalScopes = requestedScopes.filter((s) => allowedScopes.includes(s))
-  const requiredApplications = TEMPLATE_DATA.addScopesToIdTokenApplications
-
-  if (requiredApplications.includes(clientId)) {
-    const namespace: string = TEMPLATE_DATA.namespace
-    api.idToken.setCustomClaim(`${namespace}/scope`, finalScopes.join(' '))
-  }
 }


### PR DESCRIPTION
_Can be merged into dev once #59 is merged_

This removes anything related to Giving What We Can from the Auth0 Actions code.

I believe EA Funds can be removed also at this point, because they no longer have login on their site. I'm leaving it in as a precaution for now to first check whether the application is still used anywhere (e.g. by admins)
