### PR TITLE
Fix issue with import in ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "pg": "8.7.1"
   },
   "devDependencies": {
-    "@tepez/auth0-rules-types": "^0.3.1",
     "@types/auth0": "^2.33.4",
     "@types/bcrypt": "^3.0.1",
     "@types/diff": "^5.0.0",

--- a/scripts/db/src/get-user.ts
+++ b/scripts/db/src/get-user.ts
@@ -1,11 +1,5 @@
 import { MongoClient } from 'mongodb'
-import {
-  CallbackUser,
-  DbConfiguration,
-  DbScriptCallback,
-  ForumUser,
-} from '../types/db-types'
-import '@tepez/auth0-rules-types'
+import { CallbackUser, DbScriptCallback, ForumUser } from '../types/db-types'
 
 // TODO: This is pretty copy-pasta-y from login. We should fix this by building
 // good code-sharing functionality into this repo. But notice that we can't just
@@ -34,13 +28,7 @@ async function getByEmail(email: string, callback: DbScriptCallback) {
     /** Get required dependencies */
     const { MongoClient } = require('mongodb@4.1.0')
 
-    /**
-     * `configuration` is declared a global by @typez/auth0-rules-types, and
-     * there's no way to undo that. We must resort to a hack here to inform
-     * typescript of the actual shape of `configuration`
-     */
-    const { MONGO_URI, MONGO_DB_NAME } =
-      configuration as unknown as DbConfiguration
+    const { MONGO_URI, MONGO_DB_NAME } = configuration
 
     /**
      * Logic in this function tries to match:

--- a/scripts/db/src/login.ts
+++ b/scripts/db/src/login.ts
@@ -1,13 +1,7 @@
 import { compare } from 'bcrypt'
 import { createHash as createHash_ } from 'crypto'
 import { MongoClient } from 'mongodb'
-import {
-  CallbackUser,
-  DbConfiguration,
-  DbScriptCallback,
-  ForumUser,
-} from '../types/db-types'
-import '@tepez/auth0-rules-types'
+import { CallbackUser, DbScriptCallback, ForumUser } from '../types/db-types'
 
 /** Authenticates a user against existing user databases */
 async function login(
@@ -23,13 +17,7 @@ async function login(
     }
     const { MongoClient } = require('mongodb@4.1.0')
 
-    /**
-     * `configuration` is declared a global by @typez/auth0-rules-types, and
-     * there's no way to undo that. We must resort to a hack here to inform
-     * typescript of the actual shape of `configuration`
-     */
-    const { MONGO_URI, MONGO_DB_NAME } =
-      configuration as unknown as DbConfiguration
+    const { MONGO_URI, MONGO_DB_NAME } = configuration
 
     /**
      * Logic in this function tries to match:

--- a/scripts/db/types/db-types.d.ts
+++ b/scripts/db/types/db-types.d.ts
@@ -50,3 +50,7 @@ export type ForumUser = {
    */
   emails: { address: string; verified: boolean }[]
 }
+
+declare global {
+  const configuration: DbConfiguration
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,13 +80,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@tepez/auth0-rules-types@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@tepez/auth0-rules-types/-/auth0-rules-types-0.3.1.tgz#5417632120834e3ca71980d872f918a67545af4b"
-  integrity sha512-z60qMYiG/Leg6wynS9yujqxMGeVYfJ3N5tcXA+WzYKKPyrUvEigIijTxrJiZkBgLPHfqEZkoZF5MVKJ/4usD/w==
-  dependencies:
-    "@types/auth0" "^2.20.11"
-
 "@textlint/ast-node-types@^12.2.1":
   version "12.2.1"
   resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-12.2.1.tgz#bec1e4b02e97ff1167d057c71feeee1a80015aef"
@@ -106,7 +99,7 @@
     traverse "^0.6.6"
     unified "^9.2.2"
 
-"@types/auth0@^2.20.11", "@types/auth0@^2.33.4":
+"@types/auth0@^2.33.4":
   version "2.35.3"
   resolved "https://registry.yarnpkg.com/@types/auth0/-/auth0-2.35.3.tgz#5138cfc5191c1c8b87333913ec3e83d652d85d8e"
   integrity sha512-8LmBUPDIe0RKV7odNbFzVsP2m8LN/c9/5i3RmXxgsJAZyDh0ND73YnwtFmsSyliRI0Wn+4WZ5vaTV/jEfv9QGg==


### PR DESCRIPTION
Signup was broken by #57, with the error:
```
Invalid response code from the auth0-sandbox: HTTP 400. Cannot use import statement outside a module
```
This was caused by adding `import '@tepez/auth0-rules-types'`, which declares the global `configuration`.

The type on the `configuration` object we got from there was wrong anyway, so I have removed that import and instead declared the global in db-types.