### PR TITLE
Read legacy users from Postgres database rather than Mongo

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/bcrypt": "^3.0.1",
     "@types/diff": "^5.0.0",
     "@types/lodash": "^4.14.168",
-    "@types/mongodb": "^3.6.12",
     "@types/mz": "^2.7.3",
     "@types/node": "18.11.0",
     "@types/pg": "^8.6.5",

--- a/scripts/db/src/get-user.ts
+++ b/scripts/db/src/get-user.ts
@@ -1,9 +1,4 @@
-import {
-  CallbackUser,
-  DbConfiguration,
-  DbScriptCallback,
-  ForumUser,
-} from '../types/db-types'
+import { CallbackUser, DbScriptCallback, ForumUser } from '../types/db-types'
 import { Client as PGClient, ConnectionConfig as PGConnectionConfig } from 'pg'
 
 // TODO: This is pretty copy-pasta-y from login. We should fix this by building
@@ -71,7 +66,7 @@ async function getByEmail(email: string, callback: DbScriptCallback) {
         SELECT * FROM "Users"
         WHERE EXISTS (
           SELECT 1 FROM unnest(emails) AS email
-          WHERE LOWER(email) = LOWER($1)
+          WHERE LOWER(email->>'address') = LOWER($1)
         )
       `
       const res = await pgClient.query<ForumUser>(forumQuery, [email])

--- a/scripts/db/src/get-user.ts
+++ b/scripts/db/src/get-user.ts
@@ -1,5 +1,10 @@
-import { MongoClient } from 'mongodb'
-import { CallbackUser, DbScriptCallback, ForumUser } from '../types/db-types'
+import {
+  CallbackUser,
+  DbConfiguration,
+  DbScriptCallback,
+  ForumUser,
+} from '../types/db-types'
+import { Client as PGClient, ConnectionConfig as PGConnectionConfig } from 'pg'
 
 // TODO: This is pretty copy-pasta-y from login. We should fix this by building
 // good code-sharing functionality into this repo. But notice that we can't just
@@ -26,44 +31,68 @@ async function getByEmail(email: string, callback: DbScriptCallback) {
   //     callback(new Error("my error message"));
   try {
     /** Get required dependencies */
-    const { MongoClient } = require('mongodb@4.1.0')
+    const { Client: PGClient } = require('pg@8.7.1')
 
-    const { MONGO_URI, MONGO_DB_NAME } = configuration
+    const {
+      POSTGRES_USERNAME,
+      POSTGRES_PASSWORD,
+      POSTGRES_HOST,
+      POSTGRES_DATABASE,
+      POSTGRES_PORT,
+    } = configuration
 
     /**
      * Logic in this function tries to match:
      * EAForum/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
      */
     async function getForumUser(): Promise<CallbackUser | null> {
-      // Connect to the Forum DB
-      const mongoClient: MongoClient = new MongoClient(MONGO_URI)
-      await mongoClient.connect()
+      const pgConnectionInfo: PGConnectionConfig = {
+        user: POSTGRES_USERNAME,
+        password: POSTGRES_PASSWORD,
+        host: POSTGRES_HOST,
+        database: POSTGRES_DATABASE,
+        port: POSTGRES_PORT ? parseInt(POSTGRES_PORT) : 5432,
+        ssl: TEMPLATE_DATA.pgShouldSsl,
+      }
 
-      // Query the users collection for someone with our email
-      const matchingUsers = await mongoClient
-        .db(MONGO_DB_NAME)
-        .collection<ForumUser>('users')
-        .find({ 'emails.address': email })
-        .collation({ locale: 'en', strength: 2 })
-        .toArray()
+      /**
+       * NOTE: Temporary fix for Auth0 bug August 2022
+       * Should be reverted ASAP
+       *
+       * Update Nov 2022: Auth0 told me the bug is fixed so I tried
+       * reverting and it broke - the bug is very much not fixed :(
+       */
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 
-      await mongoClient.close()
+      const pgClient: PGClient = new PGClient(pgConnectionInfo)
+      await pgClient.connect()
 
-      if (!matchingUsers.length) {
+      const forumQuery = `
+        SELECT * FROM "Users"
+        WHERE EXISTS (
+          SELECT 1 FROM unnest(emails) AS email
+          WHERE LOWER(email) = LOWER($1)
+        )
+      `
+      const res = await pgClient.query<ForumUser>(forumQuery, [email])
+
+      await pgClient.end()
+
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1'
+
+      if (res.rows.length === 0) {
         return null
       }
-      if (matchingUsers.length > 1) {
+      if (res.rows.length > 1) {
         throw new Error('More than one user with this email address')
       }
-      const forumUser = matchingUsers[0]
+      const forumUser = res.rows[0]
 
-      // Which email did we find?
       const emailInfo = forumUser.emails.find(
         (e) => e.address.toLowerCase() === email.toLowerCase()
       )
       if (!emailInfo) {
-        // This should never happen, as they were returned by mongo because that
-        // field matched
+        // This should never happen, as they were returned because that field matched
         throw new Error(
           `User found by email ${email}, does not have that email`
         )
@@ -77,7 +106,6 @@ async function getByEmail(email: string, callback: DbScriptCallback) {
       }
     }
 
-    /** Give priority to Forum users, as the integration is newer and it has more users */
     const forumUser = await getForumUser()
     if (forumUser) {
       return callback(null, forumUser)

--- a/scripts/db/src/login.ts
+++ b/scripts/db/src/login.ts
@@ -1,6 +1,6 @@
 import { compare } from 'bcrypt'
 import { createHash as createHash_ } from 'crypto'
-import { MongoClient } from 'mongodb'
+import { Client as PGClient, ConnectionConfig as PGConnectionConfig } from 'pg'
 import { CallbackUser, DbScriptCallback, ForumUser } from '../types/db-types'
 
 /** Authenticates a user against existing user databases */
@@ -15,38 +15,66 @@ async function login(
     const { createHash } = require('crypto') as {
       createHash: typeof createHash_
     }
-    const { MongoClient } = require('mongodb@4.1.0')
+    const { Client: PGClient } = require('pg@8.7.1')
 
-    const { MONGO_URI, MONGO_DB_NAME } = configuration
+    const {
+      POSTGRES_USERNAME,
+      POSTGRES_PASSWORD,
+      POSTGRES_HOST,
+      POSTGRES_DATABASE,
+      POSTGRES_PORT,
+    } = configuration
 
     /**
      * Logic in this function tries to match:
      * EAForum/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
      */
     async function loginForumUser(): Promise<CallbackUser | null> {
-      // Connect to the Forum DB
-      const mongoClient: MongoClient = new MongoClient(MONGO_URI)
-      await mongoClient.connect()
+      const pgConnectionInfo: PGConnectionConfig = {
+        user: POSTGRES_USERNAME,
+        password: POSTGRES_PASSWORD,
+        host: POSTGRES_HOST,
+        database: POSTGRES_DATABASE,
+        port: POSTGRES_PORT ? parseInt(POSTGRES_PORT) : 5432,
+        ssl: TEMPLATE_DATA.pgShouldSsl,
+      }
 
-      // Query the users collection for someone with our email
-      const matchingUsers = await mongoClient
-        .db(MONGO_DB_NAME)
-        .collection<ForumUser>('users')
-        .find({ 'emails.address': email })
-        .collation({ locale: 'en', strength: 2 })
-        .toArray()
+      /**
+       * NOTE: Temporary fix for Auth0 bug August 2022
+       * Should be reverted ASAP
+       *
+       * Update Nov 2022: Auth0 told me the bug is fixed so I tried
+       * reverting and it broke - the bug is very much not fixed :(
+       */
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 
-      await mongoClient.close()
+      /** Construct a postgres client and connect to the server */
+      const pgClient: PGClient = new PGClient(pgConnectionInfo)
+      await pgClient.connect()
 
-      if (!matchingUsers.length) {
+      /** Query the users table for someone with our email */
+      const forumQuery = `
+        SELECT * FROM users 
+        WHERE EXISTS (
+          SELECT 1 FROM unnest(emails) AS email
+          WHERE LOWER(email) = LOWER($1)
+        )
+      `
+      const res = await pgClient.query<ForumUser>(forumQuery, [email])
+
+      /** Close the connection */
+      await pgClient.end()
+
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1'
+
+      if (res.rows.length === 0) {
         return null
       }
-      if (matchingUsers.length > 1) {
+      if (res.rows.length > 1) {
         throw new Error('More than one user with this email address')
       }
-      const forumUser = matchingUsers[0]
+      const forumUser = res.rows[0]
 
-      // Check their password
       // Meteor hashed its passwords twice, once on the client and once again on
       // the server. To preserve backwards compatibility with Meteor passwords,
       // we do the same, but do it both on the server-side
@@ -61,19 +89,12 @@ async function login(
         return null
       }
 
-      // Just in case we were dumb and did a stupid manual operation in our
-      // overly-flexible database
-      if (!Array.isArray(forumUser.emails)) {
-        throw new Error('Expected emails field to be an array')
-      }
-
       // Which email did we find?
       const emailInfo = forumUser.emails.find(
         (e) => e.address.toLowerCase() === email.toLowerCase()
       )
       if (!emailInfo) {
-        // This should never happen, as they were returned by mongo because that
-        // field matched
+        // This should never happen, as they were returned because that field matched
         throw new Error(
           `User found by email ${email}, does not have that email`
         )
@@ -87,7 +108,6 @@ async function login(
       }
     }
 
-    /** Give priority to Forum users, as the integration is newer and it has more users */
     const forumUser = await loginForumUser()
     if (forumUser) {
       return callback(null, forumUser)

--- a/scripts/db/src/login.ts
+++ b/scripts/db/src/login.ts
@@ -57,7 +57,7 @@ async function login(
         SELECT * FROM users 
         WHERE EXISTS (
           SELECT 1 FROM unnest(emails) AS email
-          WHERE LOWER(email) = LOWER($1)
+          WHERE LOWER(email->>'address') = LOWER($1)
         )
       `
       const res = await pgClient.query<ForumUser>(forumQuery, [email])

--- a/scripts/db/types/db-types.d.ts
+++ b/scripts/db/types/db-types.d.ts
@@ -31,8 +31,6 @@ export interface DbConfiguration {
   POSTGRES_HOST: string
   POSTGRES_DATABASE: string
   POSTGRES_PORT?: string
-  MONGO_URI: string
-  MONGO_DB_NAME: string
 }
 
 /** Forum user */

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,13 +109,6 @@
   resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-3.0.1.tgz#9c767594e31aa1c4ce78d23aa4351984403ca28f"
   integrity sha512-SwBrq5wb6jXP0o3O3jStdPWbKpimTImfdFD/OZE3uW+jhGpds/l5wMX9lfYOTDOa5Bod2QmOgo9ln+tMp2XP/w==
 
-"@types/bson@*":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@types/bson/-/bson-4.2.4.tgz#3bb08ab0de5dd07103fba355361814019ba2ae88"
-  integrity sha512-SG23E3JDH6y8qF20a4G9txLuUl+TCV16gxsKyntmGiJez2V9VBJr1Y8WxTBBD6OgBVcvspQ7sxgdNMkXFVcaEA==
-  dependencies:
-    bson "*"
-
 "@types/debug@^4.0.0":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -162,14 +155,6 @@
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
-
-"@types/mongodb@^3.6.12":
-  version "3.6.20"
-  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.6.20.tgz#b7c5c580644f6364002b649af1c06c3c0454e1d2"
-  integrity sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==
-  dependencies:
-    "@types/bson" "*"
-    "@types/node" "*"
 
 "@types/ms@*":
   version "0.7.31"
@@ -451,11 +436,6 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
-
-bson@*:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-6.10.1.tgz#dcd04703178f5ecf5b25de04edd2a95ec79385d3"
-  integrity sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==
 
 buffer-writer@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
When we migrated from Mongo to Postgres we kept the `bcrypt` password field for users that had it, so we can handle legacy users by connecting to our main Postgres db.

I'm making this changes within `auth0-rules` as this is the shortest path to dropping Mongo, although I am planning on porting all this logic into the main codebase so that we don't need this external database connection.

Steps to test:
1. The the forum locally on dev, and change the settings such that it uses database authentication rather than auth0:
  a. Change `auth0ClientSettings` to return `null`
  b. Change the forumType to `LessWrong` so that we can use their login interface
2. Signup a user on dev using the old database authentication:
  a. Check in the db that it has services->'password'->>'bcrypt' set
  b. Check that no user has been created in auth0
  c. Check that you can sign in and out with this user, start signed out
3. Revert the two changes in (1) to switch back to using auth0 authentication
4. Login as the user you created, and check that it is picked up as expected by auth0:
  a. The user should be created in auth0
  b. The services field of the user should be updated to have an auth0 entry
  c. For good measure you could check that you can delete the password field now and still login
  d. You could also test that e.g. you can't login to this user with just any password

If you need to redeploy the db scripts when testing (e.g. to test on staging, currently I have only pushed this to dev) run:
```bash
yarn build
yarn cli db deploy
```

You can also run `yarn cli db diff` to see what the changes will be. The credentials for dev and staging are in 1password