### PR TITLE
Deploy handling services.password not existing

### DIFF
--- a/scripts/db/src/login.ts
+++ b/scripts/db/src/login.ts
@@ -83,7 +83,7 @@ async function login(
         .digest('hex')
       const isValid = await bcrypt.compare(
         meteorClientSideHash,
-        forumUser.services.password.bcrypt
+        forumUser.services.password?.bcrypt
       )
       if (!isValid) {
         return null


### PR DESCRIPTION
The current error if you try to sign into a user which:
- Does exists
- Doesn't use email/password login
is `Cannot read property 'bcrypt' of undefined`. Changing to this gives the slightly more readable `error authenticating the user`