### PR TITLE
Add 'contact us' message for facebook login users

### DIFF
--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -132,7 +132,7 @@
         you agree to the <a href="https://effectivealtruism.org/terms-and-conditions" target="_blank" rel="noreferrer">Terms of Use</a> and <a href="https://ev.org/ops/about/privacy-policy" target="_blank" rel="noreferrer">Privacy Policy</a>.
       </div>
       <div class="secondary-box contact-us">
-        Having issues? <strong><a href="https://centreforeffectivealtruism.org/contact">Get in touch</a></strong>.
+        Having issues or looking for Facebook login?<br /><strong><a href="https://centreforeffectivealtruism.org/contact">Get in touch</a></strong>.
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
Not 100% set on the wording, but it seems not-super important, and this seems reasonable.

<img width="446" height="848" alt="Screenshot 2025-07-17 at 17 25 10" src="https://github.com/user-attachments/assets/03a52f9c-bcd7-4eae-9a5d-35baa5ec74cb" />
